### PR TITLE
update magic render, integrate new way of uploading textures

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "video-editor",
       "version": "0.1.0",
       "dependencies": {
-        "@mateuszjs/magic-render": "^0.1.0-next.12",
+        "@mateuszjs/magic-render": "^0.1.0-next.19",
         "@supabase/supabase-js": "^2.49.4",
         "@vercel/functions": "^2.0.0",
         "classnames": "^2.5.1",
@@ -3686,10 +3686,13 @@
       }
     },
     "node_modules/@mateuszjs/magic-render": {
-      "version": "0.1.0-next.12",
-      "resolved": "https://registry.npmjs.org/@mateuszjs/magic-render/-/magic-render-0.1.0-next.12.tgz",
-      "integrity": "sha512-9W14YIaDp+poDtzEHJvFrn9qy+W6XZ0aNS9NU1SSYJxUHwk4UGnWi/D0syaUBmq3QWoKyN5W9fPMl27LydW/qQ==",
+      "version": "0.1.0-next.19",
+      "resolved": "https://registry.npmjs.org/@mateuszjs/magic-render/-/magic-render-0.1.0-next.19.tgz",
+      "integrity": "sha512-DGvbGP4FTIt43RnQjR82foTiJ/KW5f8SRk9+GAy2Fdop04fqmBRMD+nMygT1Enj6PZnjftojqQMPvV6cdtdn0Q==",
       "license": "ISC",
+      "dependencies": {
+        "svg-parser": "^2.0.4"
+      },
       "engines": {
         "node": ">=20.8.1"
       }
@@ -17915,7 +17918,6 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/svg-parser/-/svg-parser-2.0.4.tgz",
       "integrity": "sha512-e4hG1hRwoOdRb37cIMSgzNsxyzKfayW6VOflrwvR+/bzrkyxY/31WkbgnQpgtrNp1SdpJvpUAGTa/ZoiPNDuRQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/svgo": {

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "dev-https": "next dev --turbopack --experimental-https"
   },
   "dependencies": {
-    "@mateuszjs/magic-render": "^0.1.0-next.12",
+    "@mateuszjs/magic-render": "^0.1.0-next.19",
     "@supabase/supabase-js": "^2.49.4",
     "@vercel/functions": "^2.0.0",
     "classnames": "^2.5.1",

--- a/src/__mocks__/@mateuszjs/magic-render.ts
+++ b/src/__mocks__/@mateuszjs/magic-render.ts
@@ -7,6 +7,7 @@ let onUpdateAssetsCallback: (assets: SerializedOutputAsset[]) => void
  * For WebGPU physical GPU is required, so far there is no way to simulate with CPU */
 export default function initMagicRenderMock(
   canvas: HTMLCanvasElement,
+  onUpdateTextures: (url: string, setNewUrl: (newUrl: string) => void) => void,
   onUpdateAssets: (assets: SerializedOutputAsset[]) => void,
   onSelectAsset: (assetId: number | null) => void
 ): Promise<CreatorAPI> {
@@ -26,6 +27,7 @@ export default function initMagicRenderMock(
     addImage: jest.fn(),
     removeAsset: jest.fn(),
     resetAssets: jest.fn(),
+    setTool: jest.fn(),
     destroy: () => {
       canvas.removeAttribute('data-magic-render-linked')
     },

--- a/src/app/api/project-textures/[id]/route.test.ts
+++ b/src/app/api/project-textures/[id]/route.test.ts
@@ -37,7 +37,7 @@ describe('downloadProjectAsset', () => {
   })
 
   test('returns error if there is an error from the database', async () => {
-    __setErrorQueue([new Error('Error during upload')])
+    __setErrorQueue([new Error('Error during upload.')])
     const response = await GET(
       createMockNextRequest({
         url: 'https://example.com/api/project-textures/1',
@@ -52,7 +52,7 @@ describe('downloadProjectAsset', () => {
   })
 
   test('propagates error from db to be returned in response', async () => {
-    __setErrorQueue([null, new Error('Error during upload')])
+    __setErrorQueue([null, new Error('Error during upload.')])
     const response = await GET(
       createMockNextRequest({
         url: 'https://example.com/api/project-textures/1',

--- a/src/app/api/project-textures/route.test.ts
+++ b/src/app/api/project-textures/route.test.ts
@@ -6,70 +6,47 @@ import { POST } from './route'
 jest.mock('@/app/api/supabaseClient')
 jest.mock('@/app/api/wrappers/session')
 
-const firstFile = new File(
-  [new Blob(['first-image-blob'], { type: 'image/png' })],
-  'first-image-blob.png'
-)
-const secondFile = new File(
-  [new Blob(['second-image-blob'], { type: 'image/png' })],
-  'second-image-blob.png'
-)
+const file = new File([new Blob(['image-blob'], { type: 'image/png' })], 'image-blob.png')
 
 const uploadAssetRequest = createMockNextRequest({
   formData: {
-    'files[]': [firstFile, secondFile],
+    file: [file],
   },
 })
 
 describe('uploadProjectAsset', () => {
   test('returns path if file was uploaded correctly', async () => {
     const response = await POST(uploadAssetRequest, mockNextContext())
-    const json = await response.json()
+    const json = await response.text()
 
-    expect(json).toEqual({
-      succeeded: ['4', '5'],
-      failed: [],
-    })
+    expect(json).toEqual('4')
 
     const expectedDB = __getCleanDBMock()
-    expectedDB.tables.project_textures.push(
-      {
-        id: '4',
-        owner_id: '1',
-      },
-      {
-        id: '5',
-        owner_id: '1',
-      }
-    )
-    expectedDB.storage['project-textures']['4'] = firstFile
-    expectedDB.storage['project-textures']['5'] = secondFile
+    expectedDB.tables.project_textures.push({
+      id: '4',
+      owner_id: '1',
+    })
+    expectedDB.storage['project-textures']['4'] = file
     expect(dbMock).toEqual(expectedDB)
   })
 
   test('returns success & error data if storage upload fails', async () => {
-    __setErrorQueue([null, new Error('Error during upload')])
+    __setErrorQueue([null, new Error('Error during upload.')])
     const response = await POST(uploadAssetRequest, mockNextContext())
     const json = await response.json()
 
     expect(json).toEqual({
-      succeeded: ['5'],
-      failed: [
-        {
-          file: 'first-image-blob.png',
-          error: 'Error during upload',
-        },
-      ],
+      error: 'Error during upload.',
     })
   })
 
   test('returns error if database insert fails', async () => {
-    __setErrorQueue([new Error('Error during upload')])
+    __setErrorQueue([new Error('Error during upload.')])
     const response = await POST(uploadAssetRequest, mockNextContext())
     const json = await response.json()
 
     expect(json).toEqual({
-      error: 'Error during upload',
+      error: 'Error during upload.',
     })
   })
 
@@ -78,7 +55,7 @@ describe('uploadProjectAsset', () => {
     const json = await response.json()
 
     expect(json).toEqual({
-      error: 'Files are missing.',
+      error: 'File is missing.',
     })
   })
 })

--- a/src/app/api/project-textures/route.ts
+++ b/src/app/api/project-textures/route.ts
@@ -5,51 +5,33 @@ import { SessionPayload, withSession } from '@/app/api/wrappers/session'
 
 async function uploadProjectAsset(session: SessionPayload, request: NextRequest) {
   const formData = await request.formData()
-  const files = formData.getAll('files[]') as File[]
+  const file = formData.get('file') as File
 
-  if (!files || files.length === 0) {
-    return getResponseError('Files are missing.')
+  if (!file || !(file instanceof File)) {
+    return getResponseError('File is missing.')
   }
 
   const { data: dbData, error: dbError } = await supabaseClient
     .from('project_textures')
-    .insert(
-      new Array(files.length).fill({
-        owner_id: session.userId,
-      })
-    )
+    .insert({
+      owner_id: session.userId,
+    })
     .select()
+    .single()
 
   if (dbError) {
     return getResponseError(dbError.message)
   }
 
-  const results = await Promise.all(
-    dbData.map((item, i) =>
-      supabaseClient.storage.from('project-textures').upload(item.id, files[i])
-    )
-  )
+  const { error: storageError } = await supabaseClient.storage
+    .from('project-textures')
+    .upload(dbData.id, file)
 
-  const successfullyUploadedIds = results
-    .map((result, i) => ({ ...result, id: dbData[i].id }))
-    .filter((result) => !result.error)
-    .map((result) => result.id)
+  if (storageError) {
+    return getResponseError(storageError.message)
+  }
 
-  const filesWhichUploadFailed = results
-    .map((result, i) => ({ ...result, file: files[i] }))
-    .filter((result) => result.error)
-    .map((result) => ({
-      file: result.file.name,
-      error: result.error!.message,
-    }))
-
-  return NextResponse.json(
-    {
-      succeeded: successfullyUploadedIds,
-      failed: filesWhichUploadFailed,
-    },
-    { status: 201 }
-  )
+  return new NextResponse(dbData.id, { status: 201 })
 }
 
 export const POST = withSession(uploadProjectAsset)

--- a/src/components/CreatorToolbox/components/UploadTexture/UploadTexture.test.tsx
+++ b/src/components/CreatorToolbox/components/UploadTexture/UploadTexture.test.tsx
@@ -42,8 +42,8 @@ describe('UploadTexture', () => {
     })
     fireEvent.click(uploadBtn)
 
-    const blob = new Blob(['image-blob'], { type: 'image/png' })
-    const file = new File([blob], 'image-blob.png')
+    const file = new Blob(['image-blob'], { type: 'image/png' })
+    // not sure why in Jest DOM allows only blob for URL.createObjectURL and not files
 
     const fileInputTrigger = screen.getByLabelText(/Upload an image/i)
 

--- a/src/components/CreatorToolbox/components/UploadTexture/UploadTexture.tsx
+++ b/src/components/CreatorToolbox/components/UploadTexture/UploadTexture.tsx
@@ -6,17 +6,14 @@ import { useState } from 'react'
 import ActionSheets from '@/components/ActionSheets/ActionSheets'
 import UploadTextures from '@/components/UploadTextures/UploadTextures'
 import useCreator from '@/hooks/useCreator/useCreator'
-import loadImagesFromAssetIds from '@/utils/loadImagesFromAssetIds'
 
 export default function UploadAsset() {
   const [usUploadShown, setIsUploadShown] = useState(false)
   const { creator } = useCreator()
 
-  async function addTextures(textureStorageIds: string[]) {
-    const images = await loadImagesFromAssetIds(textureStorageIds)
-
-    images.forEach((img) => {
-      creator.addImage(img.src)
+  async function addTextures(textureUrls: string[]) {
+    textureUrls.forEach((url) => {
+      creator.addImage(url)
     })
 
     setIsUploadShown(false)

--- a/src/components/NewProjectModal/NewProjectModal.tsx
+++ b/src/components/NewProjectModal/NewProjectModal.tsx
@@ -5,7 +5,6 @@ import InstagramIcon from 'assets/instagram-logo.svg'
 import YouTubeIcon from 'assets/youtube-logo.svg'
 import styles from './NewProjectModal.module.css'
 import UploadTextures from '@/components/UploadTextures/UploadTextures'
-import loadImagesFromAssetIds from '@/utils/loadImagesFromAssetIds'
 import { useRouter } from 'next/navigation'
 import OverlayLoader from '../OverlayLoader/OverlayLoader'
 import ActionSheets from '../ActionSheets/ActionSheets'
@@ -32,21 +31,19 @@ export default function NewProjectModal({ isOpen, close }: Props) {
   const { createProject, loading } = useProject()
   const { setInitialAssets } = useCreator()
 
-  const createProjectFrom = async (width: number, height: number, assetIds: string[]) => {
-    const images = await loadImagesFromAssetIds(assetIds)
+  const createProjectFrom = async (width: number, height: number, textureUrls: string[]) => {
+    // const images = await loadImagesFromAssetIds(assetIds)
 
-    const projectSize = images.reduce(
-      (maxSize, img) => ({
-        width: Math.max(maxSize.width, img.width),
-        height: Math.max(maxSize.height, img.height),
-      }),
-      { width, height }
-    )
+    // const projectSize = images.reduce(
+    //   (maxSize, img) => ({
+    //     width: Math.max(maxSize.width, img.width),
+    //     height: Math.max(maxSize.height, img.height),
+    //   }),
+    //   { width, height }
+    // )
 
-    createProject(projectSize.width, projectSize.height, (project) => {
-      if (images.length > 0) {
-        setInitialAssets(project.id, images)
-      }
+    createProject(0, 0, (project) => {
+      setInitialAssets(project.id, textureUrls)
       close()
       router.push(`/project/${project.id}`)
     })
@@ -55,7 +52,7 @@ export default function NewProjectModal({ isOpen, close }: Props) {
   return (
     <ActionSheets isOpen={isOpen} close={close} title="Start new project">
       <OverlayLoader loading={loading} />
-      <UploadTextures onUpload={(assetIds) => createProjectFrom(0, 0, assetIds)} />
+      <UploadTextures onUpload={(textureUrls) => createProjectFrom(0, 0, textureUrls)} />
       <p className={styles.divider}>Or</p>
       <h3 className={styles.blankCanvasTitle}>Choose a blank canvas with desired size</h3>
       <ul className={styles.blankCanvasList}>

--- a/src/components/UploadTextures/UploadTextures.tsx
+++ b/src/components/UploadTextures/UploadTextures.tsx
@@ -2,11 +2,9 @@ import { useEffect } from 'react'
 import cn from 'classnames'
 import { FileRejection, useDropzone } from 'react-dropzone'
 import styles from './UploadTextures.module.css'
-import useFetcher from '@/hooks/useFetcher/useFetcher'
-import errorStore from '@/stores/error'
 
 interface Props {
-  onUpload: (assetIds: string[]) => void
+  onUpload: (assetUrls: string[]) => void
 }
 
 const MAX_FILE_SIZE_MBs = 3
@@ -34,10 +32,6 @@ const getRejectionReason = (fileRejections: readonly FileRejection[]) => {
 }
 
 export default function UploadTextures({ onUpload }: Props) {
-  const { fetcher } = useFetcher<{
-    succeeded: string[]
-    failed: Array<{ file: string; error: string }>
-  }>()
   const { acceptedFiles, getRootProps, getInputProps, isDragAccept, isDragReject, fileRejections } =
     useDropzone({
       accept: { 'image/*': [] },
@@ -47,25 +41,7 @@ export default function UploadTextures({ onUpload }: Props) {
 
   useEffect(() => {
     if (acceptedFiles.length > 0) {
-      const formData = new FormData()
-      acceptedFiles.forEach((file) => {
-        formData.append('files[]', file)
-      })
-
-      fetcher(
-        '/api/project-textures',
-        {
-          method: 'POST',
-          formData,
-        },
-        ({ succeeded, failed }) => {
-          onUpload(succeeded)
-          if (failed.length > 0) {
-            const filesList = failed.map((f) => `${f.file} (${f.error})`).join(', ')
-            errorStore.message = `Failed to upload ${failed.length} files: ${filesList}`
-          }
-        }
-      )
+      onUpload(acceptedFiles.map((file) => URL.createObjectURL(file)))
     }
   }, [acceptedFiles])
 

--- a/src/hooks/useCreator/onTextureUpload.test.ts
+++ b/src/hooks/useCreator/onTextureUpload.test.ts
@@ -1,0 +1,104 @@
+import onTextureUpload from './onTextureUpload'
+import errorStore from '@/stores/error'
+import { server } from 'test/server'
+import { http, HttpResponse } from 'msw'
+
+describe('onTextureUpload', () => {
+  const mockSetNewUrl = jest.fn()
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+    errorStore.message = null
+  })
+
+  it('should not call endpoint when URL does not start with "blob:"', async () => {
+    const regularUrl = 'https://example.com/image.jpg'
+
+    await onTextureUpload(regularUrl, mockSetNewUrl)
+
+    expect(mockSetNewUrl).not.toHaveBeenCalled()
+    expect(errorStore.message).toBeNull()
+  })
+
+  it('should handle failure when fetching blob URL fails', async () => {
+    const blobUrl = 'blob:http://localhost:3000/some-uuid'
+
+    // Mock the blob URL to return an error
+    server.use(
+      http.get(blobUrl, () => {
+        return HttpResponse.error()
+      })
+    )
+
+    await onTextureUpload(blobUrl, mockSetNewUrl)
+
+    expect(mockSetNewUrl).not.toHaveBeenCalled()
+    expect(errorStore.message).toBe('Failed to upload file.')
+  })
+
+  it('should successfully fetch blob and upload to server', async () => {
+    const blobUrl = 'blob:http://localhost:3000/some-uuid'
+    const mockBlobData = new Uint8Array([1, 2, 3, 4])
+
+    const handlerURL = 'http://localhost:3000http://localhost:3000/some-uuid'
+    // jest dom has no clue how to handle "blob:" urls, it treats the mas relative so....
+
+    server.use(
+      http.get(handlerURL, () => {
+        return HttpResponse.arrayBuffer(mockBlobData.buffer)
+      })
+    )
+    server.use(
+      http.post('/api/project-textures', () => {
+        return new HttpResponse('texture-id-123', { status: 201 })
+      })
+    )
+
+    await onTextureUpload(blobUrl, mockSetNewUrl)
+
+    expect(mockSetNewUrl).toHaveBeenCalledWith('/api/project-textures/texture-id-123')
+    expect(errorStore.message).toBeNull()
+  })
+
+  it('should handle upload API failure', async () => {
+    const blobUrl = 'blob:http://localhost:3000/some-uuid'
+    const mockBlobData = new Uint8Array([1, 2, 3, 4])
+
+    // Mock the blob URL to return blob data
+    server.use(
+      http.get(blobUrl, () => {
+        return HttpResponse.arrayBuffer(mockBlobData.buffer)
+      }),
+      // Override the default project-textures handler to return error
+      http.post('/api/project-textures', () => {
+        return HttpResponse.json({ error: 'Upload failed' }, { status: 400 })
+      })
+    )
+
+    await onTextureUpload(blobUrl, mockSetNewUrl)
+
+    expect(mockSetNewUrl).not.toHaveBeenCalled()
+    expect(errorStore.message).toBe('Failed to upload file.')
+  })
+
+  it('should handle upload API network error', async () => {
+    const blobUrl = 'blob:http://localhost:3000/some-uuid'
+    const mockBlobData = new Uint8Array([1, 2, 3, 4])
+
+    // Mock the blob URL to return blob data
+    server.use(
+      http.get(blobUrl, () => {
+        return HttpResponse.arrayBuffer(mockBlobData.buffer)
+      }),
+      // Override the default project-textures handler to return network error
+      http.post('/api/project-textures', () => {
+        return HttpResponse.error()
+      })
+    )
+
+    await onTextureUpload(blobUrl, mockSetNewUrl)
+
+    expect(mockSetNewUrl).not.toHaveBeenCalled()
+    expect(errorStore.message).toBe('Failed to upload file.')
+  })
+})

--- a/src/hooks/useCreator/onTextureUpload.ts
+++ b/src/hooks/useCreator/onTextureUpload.ts
@@ -2,24 +2,23 @@ import errorStore from '@/stores/error'
 import fetcher from '@/utils/fetcher'
 
 export default async function onTextureUpload(url: string, setNewUrl: (newUrl: string) => void) {
-  console.log(-2)
   if (!url.startsWith('blob:')) return
-  console.log(-1)
+
   try {
     const file = await fetcher(url).then((res) => res.blob())
     const formData = new FormData()
     formData.append('file', file)
-    console.log(0)
+
     const response = await fetcher('/api/project-textures', {
       method: 'POST',
       formData,
     })
-    console.log(1, 'response.ok', response.ok, response.status)
+
     if (!response.ok) {
       errorStore.message = 'Failed to upload file.'
       return
     }
-    console.log(2)
+
     const id = (await response.text()) as string
     setNewUrl(`/api/project-textures/${id}`)
   } catch (err) {

--- a/src/hooks/useCreator/onTextureUpload.ts
+++ b/src/hooks/useCreator/onTextureUpload.ts
@@ -1,0 +1,29 @@
+import errorStore from '@/stores/error'
+import fetcher from '@/utils/fetcher'
+
+export default async function onTextureUpload(url: string, setNewUrl: (newUrl: string) => void) {
+  console.log(-2)
+  if (!url.startsWith('blob:')) return
+  console.log(-1)
+  try {
+    const file = await fetcher(url).then((res) => res.blob())
+    const formData = new FormData()
+    formData.append('file', file)
+    console.log(0)
+    const response = await fetcher('/api/project-textures', {
+      method: 'POST',
+      formData,
+    })
+    console.log(1, 'response.ok', response.ok, response.status)
+    if (!response.ok) {
+      errorStore.message = 'Failed to upload file.'
+      return
+    }
+    console.log(2)
+    const id = (await response.text()) as string
+    setNewUrl(`/api/project-textures/${id}`)
+  } catch (err) {
+    console.error(err)
+    errorStore.message = 'Failed to upload file.'
+  }
+}

--- a/src/hooks/useCreator/useCreator.test.ts
+++ b/src/hooks/useCreator/useCreator.test.ts
@@ -293,7 +293,7 @@ describe('useCreator', () => {
     it('with matching project id assets will be used right after creator initialization', async () => {
       const { result } = renderHook(useCreator)
 
-      const assets = [new Image(), new Image()]
+      const assets = ['blob:http://localhost/image-1', 'blob:http://localhost/image-2']
       await act(async () => {
         result.current.setInitialAssets(project.id, assets)
 
@@ -313,7 +313,7 @@ describe('useCreator', () => {
     it('if different project id assets will be dismissed', async () => {
       const { result } = renderHook(useCreator)
 
-      const assets = [new Image(), new Image()]
+      const assets = ['blob:http://localhost/image-1', 'blob:http://localhost/image-2']
       await act(async () => {
         result.current.setInitialAssets('2', assets)
 
@@ -329,7 +329,7 @@ describe('useCreator', () => {
     it('initial assets are used only once', async () => {
       const { result } = renderHook(useCreator)
 
-      const assets = [new Image(), new Image()]
+      const assets = ['blob:http://localhost/image-1', 'blob:http://localhost/image-2']
       await act(async () => {
         result.current.setInitialAssets(project.id, assets)
 

--- a/src/hooks/useCreator/useCreator.ts
+++ b/src/hooks/useCreator/useCreator.ts
@@ -7,13 +7,14 @@ import initMagicRender, {
   SerializedOutputAsset,
 } from '@mateuszjs/magic-render'
 import { proxy, ref, useSnapshot } from 'valtio'
+import onTextureUpload from './onTextureUpload'
 
 type MagicRender = Awaited<ReturnType<typeof initMagicRender>>
 
 interface CreatorStore {
   creator: MagicRender | null
   projectId: string | null
-  initialAssets: { projectId: string; assets: HTMLImageElement[] } | null
+  initialAssets: { projectId: string; assetUrls: string[] } | null
   selectedAssetId: number | null
   historySnapshots: SerializedOutputAsset[][]
   historySnapshotIndex: number
@@ -79,6 +80,7 @@ function useCreator() {
 
       const creator = await initMagicRender(
         canvas,
+        onTextureUpload,
         (assets) => {
           if (creatorState.historySnapshotIndex < creatorState.historySnapshots.length - 1) {
             creatorState.historySnapshots.splice(creatorState.historySnapshotIndex + 1)
@@ -97,7 +99,7 @@ function useCreator() {
 
       const initialAssets =
         creatorState.initialAssets?.projectId === project.id
-          ? creatorState.initialAssets.assets.map((img) => ({ url: img.src }))
+          ? creatorState.initialAssets.assetUrls.map((url) => ({ url }))
           : project.assets
 
       creator.resetAssets(initialAssets as SerializedInputAsset[], true)
@@ -121,8 +123,8 @@ function useCreator() {
         creatorState.historySnapshotIndex = 0
       }
     },
-    setInitialAssets(projectId: string, assets: HTMLImageElement[]) {
-      creatorState.initialAssets = ref({ projectId, assets })
+    setInitialAssets(projectId: string, assetUrls: string[]) {
+      creatorState.initialAssets = ref({ projectId, assetUrls })
     },
   }
 }

--- a/test/server-handlers.ts
+++ b/test/server-handlers.ts
@@ -26,6 +26,6 @@ export default [
     return new HttpResponse(null, { status: 204 })
   }),
   http.post('/api/project-textures', () => {
-    return HttpResponse.json({ succeeded: ['3'], failed: [] }, { status: 201 })
+    return new HttpResponse('3', { status: 201 })
   }),
 ]


### PR DESCRIPTION
Closes mateuszJS/magic-render#76

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for uploading textures directly from local files, with automatic conversion to URLs for immediate use.
  * Introduced a new upload handler that processes single texture files and returns their IDs as plain text.

* **Refactor**
  * Updated texture upload and project creation flows to use texture URLs instead of asset IDs.
  * Simplified asset initialization and management by handling arrays of URLs rather than image elements.
  * Streamlined upload components to bypass server upload logic and use local object URLs directly.

* **Bug Fixes**
  * Standardized error messages for texture upload failures.
  * Improved error handling and messaging during upload failures.

* **Tests**
  * Added and updated tests to reflect changes in upload handling, asset initialization, and error scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->